### PR TITLE
Create more specific filters

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import { columns } from "@/components/advocated-data-table/columns";
+import { DataTable } from "@/components/advocated-data-table/data-table";
 import { Button } from "@/components/ui/button";
 import { useEffect, useState } from "react";
-import { columns } from "./columns";
-import { DataTable } from "./data-table";
 
 export default function Home() {
   const [advocates, setAdvocates] = useState([]);
@@ -19,48 +19,9 @@ export default function Home() {
     });
   }, []);
 
-  const onChange = (e) => {
-    const searchTerm = e.target.value;
-
-    document.getElementById("search-term").innerHTML = searchTerm;
-
-    console.log("filtering advocates...");
-    const filteredAdvocates = advocates.filter((advocate) => {
-      return (
-        advocate.firstName.includes(searchTerm) ||
-        advocate.lastName.includes(searchTerm) ||
-        advocate.city.includes(searchTerm) ||
-        advocate.degree.includes(searchTerm) ||
-        advocate.specialties.includes(searchTerm) ||
-        advocate.yearsOfExperience.includes(searchTerm)
-      );
-    });
-
-    setFilteredAdvocates(filteredAdvocates);
-  };
-
-  const onClick = () => {
-    console.log(advocates);
-    setFilteredAdvocates(advocates);
-  };
-
   return (
     <main style={{ margin: "24px" }}>
       <h1>Solace Advocates</h1>
-      <br />
-      <br />
-      <div>
-        <p>Search</p>
-        <p>
-          Searching for: <span id="search-term"></span>
-        </p>
-        <input style={{ border: "1px solid black" }} onChange={onChange} />
-        <Button variant="ghost" onClick={onClick}>
-          Reset Search
-        </Button>
-      </div>
-      <br />
-      <br />
       <DataTable columns={columns} data={filteredAdvocates} />
     </main>
   );

--- a/src/components/advocated-data-table/columns.tsx
+++ b/src/components/advocated-data-table/columns.tsx
@@ -25,6 +25,7 @@ export const columns: ColumnDef<Advocate>[] = [
   {
     accessorKey: "specialties",
     header: "Specialties",
+    filterFn: "arrIncludes",
     size: 340,
   },
   {
@@ -33,6 +34,7 @@ export const columns: ColumnDef<Advocate>[] = [
     cell: ({ row }) => (
       <div className="text-right">{row.getValue("yearsOfExperience")}</div>
     ),
+    filterFn: "includesString",
   },
   {
     accessorKey: "phoneNumber",

--- a/src/components/advocated-data-table/data-table.tsx
+++ b/src/components/advocated-data-table/data-table.tsx
@@ -1,9 +1,13 @@
 "use client";
 
+import { useState } from "react";
+
 import {
   ColumnDef,
+  ColumnFiltersState,
   flexRender,
   getCoreRowModel,
+  getFilteredRowModel,
   getPaginationRowModel,
   PaginationState,
   useReactTable,
@@ -17,8 +21,9 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { useState } from "react";
+
 import { Button } from "@/components/ui/button";
+import { Filters } from "@/components/filters";
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
@@ -33,6 +38,7 @@ export const DataTable = <TData, TValue>({
     pageIndex: 0,
     pageSize: 5,
   });
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
 
   const table = useReactTable({
     data,
@@ -40,13 +46,17 @@ export const DataTable = <TData, TValue>({
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     onPaginationChange: setPagination,
+    onColumnFiltersChange: setColumnFilters,
+    getFilteredRowModel: getFilteredRowModel(),
     state: {
       pagination,
+      columnFilters,
     },
   });
 
   return (
     <div>
+      <Filters table={table} />
       <div className="rounded-md border">
         <Table>
           <TableHeader>

--- a/src/components/filters.tsx
+++ b/src/components/filters.tsx
@@ -9,7 +9,7 @@ const Filters = <TData,>({ table }: FiltersProps<TData>) => {
   return (
     <div className="flex flex-col my-4">
       <p>Filters</p>
-      <div className="flex items-center">
+      <div className="flex items-center gap-2">
         <Input
           placeholder="First Name"
           value={

--- a/src/components/filters.tsx
+++ b/src/components/filters.tsx
@@ -1,0 +1,80 @@
+import { Table } from "@tanstack/react-table";
+import { Input } from "./ui/input";
+
+type FiltersProps<TData> = {
+  table: Table<TData>;
+};
+
+const Filters = <TData,>({ table }: FiltersProps<TData>) => {
+  return (
+    <div className="flex flex-col my-4">
+      <p>Filters</p>
+      <div className="flex items-center">
+        <Input
+          placeholder="First Name"
+          value={
+            (table.getColumn("firstName")?.getFilterValue() as string) ?? ""
+          }
+          onChange={(event) =>
+            table.getColumn("firstName")?.setFilterValue(event.target.value)
+          }
+          className="max-w-sm"
+        />
+        <Input
+          placeholder="Last Name"
+          value={
+            (table.getColumn("lastName")?.getFilterValue() as string) ?? ""
+          }
+          onChange={(event) =>
+            table.getColumn("lastName")?.setFilterValue(event.target.value)
+          }
+          className="max-w-sm"
+        />
+        <Input
+          placeholder="City"
+          value={(table.getColumn("city")?.getFilterValue() as string) ?? ""}
+          onChange={(event) =>
+            table.getColumn("city")?.setFilterValue(event.target.value)
+          }
+          className="max-w-sm"
+        />
+        <Input
+          placeholder="Degree"
+          value={(table.getColumn("degree")?.getFilterValue() as string) ?? ""}
+          onChange={(event) =>
+            table.getColumn("degree")?.setFilterValue(event.target.value)
+          }
+          className="max-w-sm"
+        />
+        <Input
+          placeholder="Specialty"
+          value={
+            (table.getColumn("specialties")?.getFilterValue() as string) ?? ""
+          }
+          onChange={(event) =>
+            table.getColumn("specialties")?.setFilterValue(event.target.value)
+          }
+          className="max-w-sm"
+        />
+        <Input
+          placeholder="Years of Experience"
+          value={
+            (table
+              .getColumn("yearsOfExperience")
+              ?.getFilterValue() as number) ?? ""
+          }
+          onChange={(event) => {
+            console.log("event.target.value", event.target.value);
+            console.log("column", table.getColumn("yearsOfExperience"));
+            table
+              .getColumn("yearsOfExperience")
+              ?.setFilterValue(event.target.value);
+          }}
+          className="max-w-sm"
+        />
+      </div>
+    </div>
+  );
+};
+
+export { Filters };

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }


### PR DESCRIPTION
This PR adds filters for each column except phone number as I don't anticipate many search by phone number. These filters are additive, meaning you can apply multiple filters at once. The place holder lets you know exactly what column the filter is being applied to, the filters can be tabbed through as well.

The current inadequacies of these filters is in the Specialties and Years of Experience. Ideally we would have a mutli-select for the Specialties and a range slider for the Years of Experience. These may be features I add later.