### PR TITLE
Optimized Pagination

### DIFF
--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,12 +1,13 @@
 import { z } from "zod"
 import db from "../../../db"
 import { advocates } from "../../../db/schema"
-import { advocateData } from "../../../db/seed/advocates"
+import { NextRequest } from "next/server"
+import { sql } from "drizzle-orm" // Import sql for raw queries if needed
 
 const zSpecialty = z.string()
 
-const zAdvodateSchema = z.object({
-  id: z.string(),
+const zAdvocateSchema = z.object({
+  id: z.string().or(z.number().transform((n) => String(n))),
   firstName: z.string(),
   lastName: z.string(),
   city: z.string(),
@@ -16,18 +17,71 @@ const zAdvodateSchema = z.object({
   phoneNumber: z.number(),
 })
 
-export type Advocate = z.infer<typeof zAdvodateSchema>
+export type Advocate = z.infer<typeof zAdvocateSchema>
 
-export async function GET() {
-  // Uncomment this line to use a database
-  const data = await db.select().from(advocates)
+export async function GET(request: NextRequest) {
+  try {
+    // Parse URL search params
+    const searchParams = request.nextUrl.searchParams
+    const page = parseInt(searchParams.get("page") || "1", 10)
+    const pageSize = parseInt(searchParams.get("pageSize") || "5", 10)
 
-  // const data = advocateData;
+    console.log("Pagination parameters:", { page, pageSize })
 
-  const result = zAdvodateSchema.safeParse(data)
-  if (!result.success) {
-    console.error("Validation failed:", result.error)
+    try {
+      // Get the total count of data
+      const allData = await db.select().from(advocates)
+      const totalCount = allData.length
+
+      // Calculate offset for pagination
+      const offset = (page - 1) * pageSize
+
+      // Get paginated data
+      const data = allData.slice(offset, offset + pageSize)
+
+      // Calculate pagination metadata
+      const totalPages = Math.ceil(totalCount / pageSize)
+      const hasNextPage = page < totalPages
+      const hasPreviousPage = page > 1
+
+      // Validate the data
+      const result = z.array(zAdvocateSchema).safeParse(data)
+
+      if (!result.success) {
+        console.error("Validation failed:", result.error)
+        return Response.json(
+          { error: "Data validation failed" },
+          { status: 500 }
+        )
+      }
+
+      return Response.json({
+        data: result.data,
+        pagination: {
+          page,
+          pageSize,
+          totalPages,
+          totalCount,
+          hasNextPage,
+          hasPreviousPage,
+        },
+      })
+    } catch (dbError) {
+      console.error("Database error:", dbError)
+      const errorMessage =
+        dbError instanceof Error ? dbError.message : "Unknown database error"
+      return Response.json(
+        { error: "Database operation failed", details: errorMessage },
+        { status: 500 }
+      )
+    }
+  } catch (error) {
+    console.error("Error fetching advocates:", error)
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error"
+    return Response.json(
+      { error: "Failed to fetch advocates", details: errorMessage },
+      { status: 500 }
+    )
   }
-
-  return Response.json({ data })
 }

--- a/src/features/advocates/components/advocate-data-table/pagintation-controls.tsx
+++ b/src/features/advocates/components/advocate-data-table/pagintation-controls.tsx
@@ -5,48 +5,71 @@ import { Button } from "@/components/ui/button"
 
 interface PaginationControlsProps<TData> {
   table: Table<TData>
+  serverPagination?: {
+    page: number
+    pageSize: number
+    totalPages: number
+    totalCount: number
+    hasNextPage: boolean
+    hasPreviousPage: boolean
+  }
+  onPageChange?: (page: number) => void
 }
 
 const PaginationControls = <TData,>({
   table,
+  serverPagination,
+  onPageChange,
 }: PaginationControlsProps<TData>) => {
+  const currentPage =
+    serverPagination?.page || table.getState().pagination.pageIndex + 1
+  const pageSize =
+    serverPagination?.pageSize || table.getState().pagination.pageSize
+  const totalItems =
+    serverPagination?.totalCount || table.getFilteredRowModel().rows.length
+
+  const startItem = (currentPage - 1) * pageSize + 1
+  const endItem = Math.min(currentPage * pageSize, totalItems)
+
+  const handlePreviousPage = () => {
+    if (serverPagination && onPageChange) {
+      onPageChange(currentPage - 1)
+    } else {
+      table.previousPage()
+    }
+  }
+
+  const handleNextPage = () => {
+    if (serverPagination && onPageChange) {
+      onPageChange(currentPage + 1)
+    } else {
+      table.nextPage()
+    }
+  }
+
   return (
     <div className="flex items-center justify-between">
       <div className="text-sm text-muted-foreground">
-        Showing{" "}
-        <span className="font-medium">
-          {table.getState().pagination.pageIndex *
-            table.getState().pagination.pageSize +
-            1}
-        </span>{" "}
-        to{" "}
-        <span className="font-medium">
-          {Math.min(
-            (table.getState().pagination.pageIndex + 1) *
-              table.getState().pagination.pageSize,
-            table.getFilteredRowModel().rows.length
-          )}
-        </span>{" "}
-        of{" "}
-        <span className="font-medium">
-          {table.getFilteredRowModel().rows.length}
-        </span>{" "}
-        advocates
+        Showing <span className="font-medium">{startItem}</span> to{" "}
+        <span className="font-medium">{endItem}</span> of{" "}
+        <span className="font-medium">{totalItems}</span> advocates
       </div>
-      <div className="flex items-center space-x-2">
+      <div className="flex items-center gap-2">
         <Button
           variant="outline"
           size="sm"
-          onClick={() => table.previousPage()}
-          disabled={!table.getCanPreviousPage()}
+          onClick={handlePreviousPage}
+          disabled={
+            !serverPagination?.hasPreviousPage && !table.getCanPreviousPage()
+          }
         >
           Previous
         </Button>
         <Button
           variant="outline"
           size="sm"
-          onClick={() => table.nextPage()}
-          disabled={!table.getCanNextPage()}
+          onClick={handleNextPage}
+          disabled={!serverPagination?.hasNextPage && !table.getCanNextPage()}
         >
           Next
         </Button>

--- a/src/features/advocates/hooks/use-advocates.ts
+++ b/src/features/advocates/hooks/use-advocates.ts
@@ -1,11 +1,9 @@
 import { useQuery } from "@tanstack/react-query"
-import { getAdvocates } from "../queries/get-advocates"
+import { getAdvocates, type AdvocateResponse } from "../queries/get-advocates"
 
-const useAdvocates = () => {
-  return useQuery({
-    queryKey: ["advocates"],
-    queryFn: getAdvocates,
+export const useAdvocates = (page = 1, pageSize = 5) => {
+  return useQuery<AdvocateResponse, Error>({
+    queryKey: ["advocates", page, pageSize],
+    queryFn: () => getAdvocates({ page, pageSize }),
   })
 }
-
-export { useAdvocates }

--- a/src/features/advocates/queries/get-advocates.ts
+++ b/src/features/advocates/queries/get-advocates.ts
@@ -1,12 +1,28 @@
-const getAdvocates = async () => {
-  const response = await fetch("/api/advocates")
+import { Advocate } from "@/app/api/advocates/route"
+
+export type AdvocateResponse = {
+  data: Advocate[]
+  pagination: {
+    page: number
+    pageSize: number
+    totalPages: number
+    totalCount: number
+    hasNextPage: boolean
+    hasPreviousPage: boolean
+  }
+}
+
+export const getAdvocates = async ({
+  page = 1,
+  pageSize = 5,
+} = {}): Promise<AdvocateResponse> => {
+  const response = await fetch(
+    `/api/advocates?page=${page}&pageSize=${pageSize}`
+  )
 
   if (!response.ok) {
     throw new Error("Failed to fetch advocates")
   }
 
-  const data = await response.json()
-  return data.data
+  return response.json()
 }
-
-export { getAdvocates }


### PR DESCRIPTION
I updated the GET to only return the number of records we've passed along in the pageSize param. This means we only render what's returned, but we are caching the pages. So the first time you navigate to page 2 you'll load record 6 - 10, but then next time will be immediate. Unfortunately, this has introduced a bug as our filters are still client side. I'll address that in the next PR.